### PR TITLE
Fix: add break between party commands to prevent both being triggered

### DIFF
--- a/features/general/PartyCommands.js
+++ b/features/general/PartyCommands.js
@@ -235,6 +235,7 @@ register("chat", (player, message) => {
                     ChatLib.command("pc Coins: " + formatNumber(dianaTrackerMayor["items"]["coins"]))
                 }, 200)
             }
+            break
         case "!mob":
         case "!mobs":
             if (settings.dianaTracker && settings.dianaPartyCommands) {


### PR DESCRIPTION
Added a break between !coins and !mobs commands in party commands to prevent both from triggering